### PR TITLE
[DIST/Tizen] Add spec and manifest files

### DIFF
--- a/packaging/ros-kinetic-roslisp.manifest
+++ b/packaging/ros-kinetic-roslisp.manifest
@@ -1,0 +1,5 @@
+<manifest>
+  <request>
+    <domain name="_"/>
+  </request>
+</manifest>

--- a/packaging/ros-kinetic-roslisp.spec
+++ b/packaging/ros-kinetic-roslisp.spec
@@ -10,9 +10,11 @@ Source1001:     %{name}.manifest
 BuildRequires:  ros-kinetic-catkin
 Requires:       ros-kinetic-roslang
 Requires:       ros-kinetic-rospack
-Requires:       sbcl
 Requires:       ros-kinetic-rosgraph-msgs
 Requires:       ros-kinetic-std-srvs
+
+# Workaround to resolve the circular dependency in sbcl package
+# Requires:       sbcl
 
 %description
 Lisp client library for ROS, the Robot Operating System

--- a/packaging/ros-kinetic-roslisp.spec
+++ b/packaging/ros-kinetic-roslisp.spec
@@ -1,0 +1,34 @@
+Name:           ros-kinetic-roslisp
+Version:        1.9.21
+Release:        0
+Summary:        Lisp client library for ROS, the Robot Operating System
+Group:          Development/Libraries
+License:        BSD
+URL:            http://ros.org/wiki/roslisp
+Source0:        %{name}-%{version}.tar.gz
+Source1001:     %{name}.manifest
+BuildRequires:  ros-kinetic-catkin
+Requires:       ros-kinetic-roslang
+Requires:       ros-kinetic-rospack
+Requires:       sbcl
+Requires:       ros-kinetic-rosgraph-msgs
+Requires:       ros-kinetic-std-srvs
+
+%description
+Lisp client library for ROS, the Robot Operating System
+
+%prep
+%setup -q
+cp %{SOURCE1001} .
+
+%build
+%{__ros_setup}
+%{__ros_build}
+
+%install
+%{__ros_setup}
+%{__ros_install}
+
+%files -f build/install_manifest.txt
+%manifest %{name}.manifest
+%defattr(-,root,root)


### PR DESCRIPTION
This PR just imports the following patches from sec.github. 

packaging: remove sbcl requires as workaround
packaging: add spec and manifest files
    
Signed-off-by: Sangjung woo <sangjung.woo@samsung.com>
Signed-off-by: Wook Song <wook16.song@samsung.com>